### PR TITLE
Improve captcha message

### DIFF
--- a/ikabot/helpers/botComm.py
+++ b/ikabot/helpers/botComm.py
@@ -58,7 +58,7 @@ def sendToBot(session, msg, Token=False, Photo=None):
         # we need to clear the headers here because telegram doesn't like keep-alive, might as well get rid of all headers
         headers = session.s.headers.copy()
         session.s.headers.clear()
-        resp = session.s.post('https://api.telegram.org/bot{}/sendDocument'.format(telegram_data['botToken']), files={'document': ('captcha.png', Photo)}, data={'chat_id': telegram_data['chatId'],'caption': msg})
+        resp = session.s.post('https://api.telegram.org/bot{}/sendPhoto'.format(telegram_data['botToken']), files={'photo': ('captcha.png', Photo)}, data={'chat_id': telegram_data['chatId'],'caption': msg})
         session.s.headers = headers
 
 


### PR DESCRIPTION
Improvement to the captcha message by sending the image as a photo instead of a document. The image embedding is better on Telegram at least for the Desktop (PC) version, unfortunately the image's wide size kinda ruins it for the mobile but I guess that can't be helped. It's still a little better for mobile as well, though. 