### PR TITLE
Confirm data deletion

### DIFF
--- a/ikabot/helpers/aesCipher.py
+++ b/ikabot/helpers/aesCipher.py
@@ -84,11 +84,15 @@ class AESCipher:
                 try:
                     plaintext = self.decrypt(ciphertext)
                 except Exception:
-                    msg = _('Error while decrypting session data\nSaved data will be deleted.')
+                    msg = _('Error while decrypting session data.\nYou may have entered a wrong password.')
                     if session.padre:
                         print(msg)
                     else:
                         sendToBot(session, msg)
+                    print(_('\nWould you like to format .ikabot userdata? [y/N]'))
+                    rta = read(values=['n', 'N', 'y', 'Y', ''])
+                    if rta.lower() == 'n' or rta == '':
+                        os._exit(0)
                     self.deleteSessionData(session)
                     os._exit(0)
                 data_dict = json.loads(plaintext, strict=False)

--- a/ikabot/helpers/aesCipher.py
+++ b/ikabot/helpers/aesCipher.py
@@ -89,9 +89,9 @@ class AESCipher:
                         print(msg)
                     else:
                         sendToBot(session, msg)
-                    print(_('\nWould you like to format .ikabot userdata? [y/N]'))
-                    rta = read(values=['n', 'N', 'y', 'Y', ''])
-                    if rta.lower() == 'n' or rta == '':
+                    print(_('\nWould you like to delete the ikabot session data associated with this email address? [y/N]'))
+                    rta = read(values=['n', 'N', 'y', 'Y'])
+                    if rta.lower() == 'n':
                         os._exit(0)
                     self.deleteSessionData(session)
                     os._exit(0)


### PR DESCRIPTION
Added a Y/N confirmation in session data deletion in case decryption fails. Happens most often by inserting a wrong password. Since the password cannot be seen when typed in, users could easily be confused why it keeps deleting the data when trying to log in. Now it states a probable cause and asks for a confirmation to save the user from having to re-enter all data again. 

When inserting a wrong **email** _and_ password, the user data is not deleted and the cause is obvious & printed out. 