### PR TITLE
Update Docker Workflow

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -1,15 +1,19 @@
-name: Publish Docker image
+name: Publish Docker Image
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ikabot
 
 jobs:
   build-and-push-image:
+    name: Build & Publish
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -19,23 +23,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      # The repository name must be in lower case in order to be pushed to the registry
+      - name: Set lower case owner name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push Docker image
+      
+      - name: Build and push
         uses: docker/build-push-action@v4
         with:
-          context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:${{ inputs.tag_name }}
+            ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/publish_docker_manually.yml
+++ b/.github/workflows/publish_docker_manually.yml
@@ -1,0 +1,19 @@
+name: Publish Docker Image Manually
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag for the image (ex: v6.5.1)'
+        required: true
+        type: string
+
+jobs:
+  publish_docker:
+    name: Build & Publish Docker Image
+    uses: ./.github/workflows/publish_docker.yml
+    with:
+      tag_name: ${{ inputs.tag_name }}
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       milestone:
-        description: 'The milestone to generate a release for'
+        description: 'The milestone to generate a release for (ex: 6.5.1)'
         required: true
         type: string
 
@@ -112,7 +112,7 @@ jobs:
           gh release edit v${{ inputs.milestone }} --repo '${{ github.repository }}' --draft=false          
 
   close_milestone:
-    needs: [create_release]
+    needs: [publish_release]
     runs-on: ubuntu-latest
     name: Close Milestone
 
@@ -127,3 +127,13 @@ jobs:
           $milestones = $(gh milestone list --json number,title) | ConvertFrom-Json
           $milestoneNumber = ($milestones | Where-Object { $_.title -eq "${{ inputs.milestone }}" }).number
           gh milestone edit $milestoneNumber --state closed
+
+  publish_docker:
+    needs: [publish_release]
+    name: Publish Docker Image
+    uses: ./.github/workflows/publish_docker.yml
+    with:
+      tag_name: 'v${{ inputs.milestone }}'
+    permissions:
+      contents: read
+      packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3
 
+LABEL org.opencontainers.image.description="The image includes all the necessary dependencies and configurations to run Ikabot seamlessly."
+LABEL org.opencontainers.image.source="https://github.com/physics-sec/ikabot"
+LABEL org.opencontainers.image.licenses="MIT"
+
 WORKDIR /ikabot
 COPY . .
 


### PR DESCRIPTION
I've updated the workflow for publishing docker images.
A new image should now be published automatically when a new release is published. 
I tested it on my personal repo and it works fine. So this should fix the issue #128
I've also added the possibility of publishing an image manually.
If all goes well, we should update the readme to include the ability to use pre-built images from the registry.
@ikagod @physics-sec 