### PR TITLE
Fix buy/sellResources functions

### DIFF
--- a/ikabot/function/buyResources.py
+++ b/ikabot/function/buyResources.py
@@ -14,6 +14,7 @@ from ikabot.helpers.getJson import getCity
 from ikabot.helpers.signals import setInfoSignal
 from ikabot.helpers.planRoutes import waitForArrival
 from ikabot.helpers.pedirInfo import getIdsOfCities, read
+from ikabot.helpers.naval import getTotalShips
 from ikabot.config import *
 from ikabot.helpers.botComm import *
 from ikabot.helpers.resources import *
@@ -241,7 +242,7 @@ def buyResources(session, event, stdin_fd, predetermined_input):
         session.logout()
 
 
-def buy(session, city, offer, amount_to_buy):
+def buy(session, city, offer, amount_to_buy, ships_available):
     """
     Parameters
     ----------
@@ -264,6 +265,7 @@ def buy(session, city, offer, amount_to_buy):
         'activeTab': 'bargain',
         'transportDisplayPrice': 0,
         'premiumTransporter': 0,
+        'normalTransportersMax': ships_available,
         'capacity': 5,
         'max_capacity': 5,
         'jetPropulsion': 0,
@@ -318,6 +320,6 @@ def do_it(session, city, offers, amount_to_buy):
 
             amount_to_buy -= buy_amount
             offer['amountAvailable'] -= buy_amount
-            buy(session, city, offer, buy_amount)
+            buy(session, city, offer, buy_amount, ships_available)
             # start from the beginning again, so that we always buy from the cheapest offers fisrt
             break

--- a/ikabot/function/sellResources.py
+++ b/ikabot/function/sellResources.py
@@ -121,7 +121,6 @@ def sellToOffers(session, city_to_buy_from, resource_type, event):
 
     available = city_to_buy_from['recursos'][resource_type]
     amount_to_sell = min(available, total_amount)
-    transportersMax = getTotalShips(session)
 
     banner()
     print(_('\nHow much do you want to sell? [max = {}]').format(addThousandSeparator(amount_to_sell)))
@@ -153,7 +152,7 @@ def sellToOffers(session, city_to_buy_from, resource_type, event):
     info = _('\nI sell {} of {} in {}\n').format(addThousandSeparator(amount_to_sell), materials_names[resource_type], city_to_buy_from['name'])
     setInfoSignal(session, info)
     try:
-        do_it1(session, amount_to_sell, chosen_offers, resource_type, city_to_buy_from, transportersMax)
+        do_it1(session, amount_to_sell, chosen_offers, resource_type, city_to_buy_from)
     except Exception as e:
         msg = _('Error in:\n{}\nCause:\n{}').format(info, traceback.format_exc())
         sendToBot(session, msg)
@@ -251,7 +250,7 @@ def sellResources(session, event, stdin_fd, predetermined_input):
         return
 
 
-def do_it1(session, left_to_sell, offers, resource_type, city_to_buy_from, transportersMax):
+def do_it1(session, left_to_sell, offers, resource_type, city_to_buy_from):
     """
     Parameters
     ----------
@@ -260,7 +259,6 @@ def do_it1(session, left_to_sell, offers, resource_type, city_to_buy_from, trans
     offers : list[dict]
     resource_type : int
     city_to_buy_from : dict
-    transportersMax: int
     """
     for offer in offers:
         cityname, username, amount, precio, dist, destination_city_id = offer
@@ -277,7 +275,7 @@ def do_it1(session, left_to_sell, offers, resource_type, city_to_buy_from, trans
             left_to_sell -= amount_to_sell
             amount_to_buy -= amount_to_sell
 
-            data = {'action': 'transportOperations', 'function': 'sellGoodsAtAnotherBranchOffice', 'cityId': city_to_buy_from['id'], 'destinationCityId': destination_city_id, 'oldView': 'branchOffice', 'position': city_to_buy_from['pos'], 'avatar2Name': username, 'city2Name': cityname, 'type': '333', 'activeTab': 'bargain', 'transportDisplayPrice': '0', 'premiumTransporter': '0', 'normalTransportersMax': transportersMax, 'capacity': '5', 'max_capacity': '5', 'jetPropulsion': '0', 'transporters': str(ships_used), 'backgroundView': 'city', 'currentCityId': city_to_buy_from['id'], 'templateView': 'takeOffer', 'currentTab': 'bargain', 'actionRequest': actionRequest, 'ajax': '1'}
+            data = {'action': 'transportOperations', 'function': 'sellGoodsAtAnotherBranchOffice', 'cityId': city_to_buy_from['id'], 'destinationCityId': destination_city_id, 'oldView': 'branchOffice', 'position': city_to_buy_from['pos'], 'avatar2Name': username, 'city2Name': cityname, 'type': '333', 'activeTab': 'bargain', 'transportDisplayPrice': '0', 'premiumTransporter': '0', 'normalTransportersMax': ships_available, 'capacity': '5', 'max_capacity': '5', 'jetPropulsion': '0', 'transporters': str(ships_used), 'backgroundView': 'city', 'currentCityId': city_to_buy_from['id'], 'templateView': 'takeOffer', 'currentTab': 'bargain', 'actionRequest': actionRequest, 'ajax': '1'}
             if resource_type == 0:
                 data['cargo_resource'] = amount_to_sell
                 data['resourcePrice'] = precio


### PR DESCRIPTION
Changed the amount of ships to use in transport from max to the available ships. Fixes the issue when only one transport is made if all ships were available instead of continuously sending transports whenever ships become available until the quota is reached.

Fixes the issues mentioned in #154 and #156 