### PR TITLE
Fix: predetermined input made readonly functions to not show properly

### DIFF
--- a/ikabot/command_line.py
+++ b/ikabot/command_line.py
@@ -186,6 +186,7 @@ def menu(session, checkUpdate=True):
     if selected != 0:
         try:
             event = multiprocessing.Event()  # creates a new event
+            config.has_params = len(config.predetermined_input) > 0
             process = multiprocessing.Process(target=menu_actions[selected], args=(session, event, sys.stdin.fileno(), config.predetermined_input), name=menu_actions[selected].__name__)
             process.start()
             process_list.append({'pid': process.pid, 'action': menu_actions[selected].__name__, 'date': time.time()})


### PR DESCRIPTION
Some functions like export cookie, account information and ship info wouldn't wait for enter if you login with predetermined input

Since those functions doesn't return data or have any kind of automation purpose (to my knowelege) then they should ignore config.has_params and wait for the user to press enter.

Another alternative would be to set config.has_params to false once the predetermined input automation is all done.