### PR TITLE
Rework main menu to be easier for maintaining

### DIFF
--- a/ikabot/command_line.py
+++ b/ikabot/command_line.py
@@ -48,169 +48,123 @@ from ikabot.function.testTelegramBot import testTelegramBot
 t = gettext.translation('command_line', localedir, languages=languages, fallback=True)
 _ = t.gettext
 
+__function_refresh = 'refresh'
+__function_exit = 'exit'
 
-def menu(session, checkUpdate=True):
+__command_back = ['Back', __function_refresh]
+
+_global_menu = [
+    ['Exit', __function_exit],
+    ['Construction list', constructionList],
+    ['Send resources', sendResources],
+    ['Distribute resources', distributeResources],
+    ['Account status', getStatus],
+    ['Monitor islands', searchForIslandSpaces],
+    ['Login daily', loginDaily],
+    ['Alerts / Notifications', [
+        __command_back,
+        ['Alert attacks', alertAttacks],
+        ['Alert wine running out', alertLowWine],
+    ]],
+    ['Marketplace', [
+        __command_back,
+        ['Buy resources', buyResources],
+        ['Sell resources', sellResources],
+    ]],
+    ['Donate', [
+        __command_back,
+        ['Donate once', donate],
+        ['Donate automatically', donationBot],
+    ]],
+    ['Activate vacation mode', vacationMode],
+    ['Activate miracle', activateMiracle],
+    ['Military actions', [
+        __command_back,
+        ['Train Army', trainArmy],
+        ['Send Troops/Ships', stationArmy],
+    ]],
+    ['See movements', shipMovements],
+    ['Construct building', constructBuilding],
+    ['Update Ikabot', update],
+    ['Import / Export cookie', importExportCookie],
+    ['Auto-Pirate', autoPirate],
+    ['Investigate', investigate],
+    ['Attack barbarians', attackBarbarians],
+    ['Dump / View world', dumpWorld],
+    ['Options / Settings', [
+        __command_back,
+        ['Configure Proxy', proxyConf],
+        ['Telegram Bot', [
+            __command_back,
+            ['Change bot data', updateTelegramData],
+            ['Test message the bot', testTelegramBot],
+        ]],
+        ['Kill tasks', killTasks],
+        ['Configure captcha resolver', decaptchaConf],
+        ['Logs', logs],
+    ]],
+    ['Refresh process info', __function_refresh],
+]
+
+
+def choose_from_menu(menu_options, prefix=''):
+    for ind, option in enumerate(menu_options):
+        print(prefix, "{: >3})".format(ind), option[0])
+    selected = read(min=0, max=len(menu_options)-1, digit=True)
+
+    print()
+    [name, fn] = menu_options[selected]
+    print(prefix, 'Selected {}) {}'.format(selected, name))
+    if type(fn) is list:
+        return choose_from_menu(fn, prefix + '  ')
+
+    return fn
+
+def menu(session):
     """
     Parameters
     ----------
     session : ikabot.web.session.Session
-    checkUpdate : bool
     """
-    if checkUpdate:
-        checkForUpdate()
-
+    checkForUpdate()
     show_proxy(session)
-
-    banner()
-
     process_list_manager = IkabotProcessListManager(session)
-    process_list_manager.print_proces_table()
 
-    menu_actions = {
-        1:            constructionList,
-        2:            sendResources,
-        3:            distributeResources,
-        4:            getStatus,
-        5:            searchForIslandSpaces,
-        6:            loginDaily,
-        101:            alertAttacks,
-        102:            alertLowWine,
-        111:            buyResources,
-        112:            sellResources,
-        121:            donate,
-        122:            donationBot,
-        10:            vacationMode,
-        11:            activateMiracle,
-        131:            trainArmy,
-        132:            stationArmy,
-        13:            shipMovements,
-        14:            constructBuilding,
-        15:            update,
-        16:            importExportCookie,
-        17:            autoPirate,
-        18:            investigate,
-        19:            attackBarbarians,
-        20:            dumpWorld,
-        141:            proxyConf,
-        142:            updateTelegramData,
-        143:            killTasks,
-        144:            decaptchaConf,
-        145:            logs,
-        146:            testTelegramBot,
-                    }
-
-    print(_('(0)  Exit'))
-    print(_('(1)  Construction list'))
-    print(_('(2)  Send resources'))
-    print(_('(3)  Distribute resources'))
-    print(_('(4)  Account status'))
-    print(_('(5)  Monitor islands'))
-    print(_('(6)  Login daily'))
-    print(_('(7)  Alerts / Notifications'))
-    print(_('(8)  Marketplace'))
-    print(_('(9)  Donate'))
-    print(_('(10) Activate vacation mode'))
-    print(_('(11) Activate miracle'))
-    print(_('(12) Military actions'))
-    print(_('(13) See movements'))
-    print(_('(14) Construct building'))
-    print(_('(15) Update Ikabot'))
-    print(_('(16) Import / Export cookie'))
-    print(_('(17) Auto-Pirate'))
-    print(_('(18) Investigate'))
-    print(_('(19) Attack barbarians'))
-    print(_('(20) Dump / View world'))
-    print(_('(21) Options / Settings'))
-    total_options = len(menu_actions) + 1
-    selected = read(min=0, max=total_options, digit=True)
-    
-    if selected == 7:
+    while True:
         banner()
-        print(_('(0) Back'))
-        print(_('(1) Alert attacks'))
-        print(_('(2) Alert wine running out'))
 
-        selected = read(min=0, max=2, digit=True)
-        if selected == 0:
-            menu(session)
-            return
-        if selected > 0:
-            selected += 100
-            
-    if selected == 8:
-        banner()
-        print(_('(0) Back'))
-        print(_('(1) Buy resources'))
-        print(_('(2) Sell resources'))
+        process_list_manager.print_proces_table()
 
-        selected = read(min=0, max=2, digit=True)
-        if selected == 0:
-            menu(session)
-            return
-        if selected > 0:
-            selected += 110
-            
-    if selected == 9:
-        banner()
-        print(_('(0) Back'))
-        print(_('(1) Donate once'))
-        print(_('(2) Donate automatically'))
-
-        selected = read(min=0, max=2, digit=True)
-        if selected == 0:
-            menu(session)
-            return
-        if selected > 0:
-            selected += 120
-            
-    if selected == 12:
-        banner()
-        print(_('(0) Back'))
-        print(_('(1) Train Army'))
-        print(_('(2) Send Troops/Ships'))
-        selected = read(min=0, max=2, digit=True)
-        if selected == 0:
-            menu(session)
-            return
-        if selected > 0:
-            selected += 130
-
-    if selected == 21:
-        banner()
-        print(_('(0) Back'))
-        print(_('(1) Configure Proxy'))
-        if telegramDataIsValid(session):
-            print(_('(2) Change the Telegram data'))
-        else:
-            print(_('(2) Enter the Telegram data'))
-        print(_('(3) Kill tasks'))
-        print(_('(4) Configure captcha resolver'))
-        print(_('(5) Logs'))
-        print(_('(6) Message Telegram Bot'))
-
-        selected = read(min=0, max=6, digit=True)
-        if selected == 0:
-            menu(session)
-            return
-        if selected > 0:
-            selected += 140
-        
-
-
-    if selected != 0:
         try:
+            selected = choose_from_menu(_global_menu)
+
+            if selected == __function_exit:
+                # Perform exit of the app
+                if isWindows:
+                    # in unix, you can exit ikabot and close the terminal and the processes will continue to execute
+                    # in windows, you can exit ikabot but if you close the terminal, the processes will die
+                    print(_('Closing this console will kill the processes.'))
+                    enter()
+                clear()
+                os._exit(0)  # kills the process which executes this statement, but it does not kill it's child processes
+
+            if selected == __function_refresh:
+                # we just need to refresh the menu
+                continue
+
+            # we've selected a function, let's execute it
             event = multiprocessing.Event()  # creates a new event
             config.has_params = len(config.predetermined_input) > 0
             process = multiprocessing.Process(
-                target=menu_actions[selected],
+                target=selected,
                 args=(session, event, sys.stdin.fileno(), config.predetermined_input),
-                name=menu_actions[selected].__name__
+                name=selected.__name__
             )
 
             process.start()
             process_list_manager.add_process({
                 'pid': process.pid,
-                'action': menu_actions[selected].__name__,
+                'action': selected.__name__,
                 'date': time.time(),
                 'status': 'started'
             })
@@ -221,16 +175,6 @@ def menu(session, checkUpdate=True):
             event.wait()
         except KeyboardInterrupt:
             pass
-        menu(session, checkUpdate=False)
-    else:
-        if isWindows:
-            # in unix, you can exit ikabot and close the terminal and the processes will continue to execute
-            # in windows, you can exit ikabot but if you close the terminal, the processes will die
-            print(_('Closing this console will kill the processes.'))
-            enter()
-        clear()
-        os._exit(0)  # kills the process which executes this statement, but it does not kill it's child processes
-
 
 def init():
     home = 'USERPROFILE' if isWindows else 'HOME'


### PR DESCRIPTION
Currently all of the code that prints the menu is hard to follow. There is a dict with the number to function, but some of them are hidden in a sub-menu. This is hard for maintaining and you need to change multiple things to get one more option.

This being said, I've reworked the menu to:
1. Not use recursion. It was hard to follow and was checking only once for updates - on application start. This logic remains the same.
2. Allow nested menues to be easier to read and maintain. In the proposed implementation the each menu item is represented as an list. The first argument is the title to display to the user, and the second one - either a function or an array of menu items. This way we represend the submenu.
3. Added refresh function to allow only refreshing the process table without executing a function