### PR TITLE
Fix nslookup error when using docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3
 
+# Add labels to describe the Docker image
 LABEL org.opencontainers.image.description="The image includes all the necessary dependencies and configurations to run Ikabot seamlessly."
 LABEL org.opencontainers.image.source="https://github.com/physics-sec/ikabot"
 LABEL org.opencontainers.image.licenses="MIT"
@@ -7,6 +8,10 @@ LABEL org.opencontainers.image.licenses="MIT"
 WORKDIR /ikabot
 COPY . .
 
-RUN ["python3", "-m", "pip", "install", "--user", "-e", "."]
+# Install dependencies
+RUN pip install --upgrade pip
+RUN pip install -e .
+RUN apt-get update
+RUN apt-get install dnsutils -y
 
 CMD "python3" "-m" "ikabot"


### PR DESCRIPTION
Fix #191 

I added the instruction to install nslookup in the dockerfile and it seems to fix the problem.
![image](https://github.com/physics-sec/ikabot/assets/54487782/3714eacd-0429-4e7a-89ff-1bdb1e03d9f7)

Knowing that the docker image provided by python is a linux debian, I've added the instructions provided in this article https://www.curiouslychase.com/posts/install-dig-and-nslookup-dependencies-on-docker-containers/