### PR TITLE
Ability to choose which city to ignore from distribution of resources.

### DIFF
--- a/tests/function/test_distributeResources.py
+++ b/tests/function/test_distributeResources.py
@@ -8,11 +8,11 @@ from ikabot.function.distributeResources import distribute_evenly
 
 
 def test_distribute_evenly(monkeypatch, session, cities):
-    monkeypatch.setattr(ikabot.function.distributeResources, "getIdsOfCities", lambda s: ([city["id"] for city in cities], cities))
+    cities_ids = [city["id"] for city in cities]
     monkeypatch.setattr(ikabot.function.distributeResources, "getCity", lambda city: city)
 
     # test
-    routes = distribute_evenly(session, materials_names_tec.index("wine"))
+    routes = distribute_evenly(session, materials_names_tec.index("wine"), cities_ids, cities)
 
     sorted_routes = sorted(routes, key=lambda route: route[1]["id"])
 


### PR DESCRIPTION
I need the ability to choose which cities to ignore when redistributing the resources because I use a floater to farm barbarians and I don't want to move any of my resources there.

That's why I made this pull request, which adds this function.